### PR TITLE
US64560

### DIFF
--- a/queue-ci-message.js
+++ b/queue-ci-message.js
@@ -17,8 +17,8 @@ var queueCiMessage = function(){
 
   var message = {
     url: 'https://git.dev.d2l/scm/an/ap.git',
-    path: 'insightsPortal/_config/AppLoader/Apps/' + process.env.FRA_JSON,
-    key: process.env.FRA_KEY,
+    path: 'insightsPortal/_config/AppLoader/Apps/' + process.env.FRA_NAME + '.json',
+    key: 'urn:d2l:fra:class:' + process.env.FRA_NAME,
     version: appPublisher.getLocation() + 'appconfig.json'
   };
 

--- a/queue-ci-message.js
+++ b/queue-ci-message.js
@@ -1,0 +1,45 @@
+var ironMQ = require('iron_mq'),
+  frauPublisher = require('frau-publisher'),
+  publishOptions = require('../.publish_options.js');
+
+
+var queueCiMessage = function(){
+  var imq = new ironMQ.Client( {
+    token: process.env.IRON_IO_TOKEN,
+    project_id: process.env.IRON_IO_ID,
+    queue_name: process.env.IRON_QUEUE_NAME
+  });
+
+  console.log('Queue Name: ' + process.env.IRON_QUEUE_NAME);
+  console.log('Publishing Options: ' + publishOptions);
+  var queue = imq.queue(process.env.IRON_QUEUE_NAME),
+    appPublisher = frauPublisher.app(publishOptions);
+
+  var message = {
+    url: 'https://git.dev.d2l/scm/an/ap.git',
+    path: 'insightsPortal/_config/AppLoader/Apps/' + process.env.FRA_JSON,
+    key: process.env.FRA_KEY,
+    version: appPublisher.getLocation() + 'appconfig.json'
+  };
+
+  queue.post( JSON.stringify(message), function( error, body ){
+    if (error !== null){
+      console.log( 'Error publishing to Iron.io: ' + error );
+    }
+    if (body !== null ){
+      console.log( 'Message back from Iron.io: ' + body );
+    }
+  });
+};
+
+/*
+if (process.env.TRAVIS_BRANCH == 'master' && process.env.TRAVIS_PULL_REQUEST == 'false') {
+  queueCiMessage();
+}
+else {
+  console.log('This is not a commit to master, not sending message to CI queue');
+}*/
+
+
+queueCiMessage();
+

--- a/queue-ci-message.js
+++ b/queue-ci-message.js
@@ -2,7 +2,6 @@ var ironMQ = require('iron_mq'),
   frauPublisher = require('frau-publisher'),
   publishOptions = require('../.publish_options.js');
 
-
 var queueCiMessage = function(){
   var imq = new ironMQ.Client( {
     token: process.env.IRON_IO_TOKEN,
@@ -12,6 +11,7 @@ var queueCiMessage = function(){
 
   console.log('Queue Name: ' + process.env.IRON_QUEUE_NAME);
   console.log('Publishing Options: ' + publishOptions);
+
   var queue = imq.queue(process.env.IRON_QUEUE_NAME),
     appPublisher = frauPublisher.app(publishOptions);
 
@@ -32,14 +32,10 @@ var queueCiMessage = function(){
   });
 };
 
-/*
 if (process.env.TRAVIS_BRANCH == 'master' && process.env.TRAVIS_PULL_REQUEST == 'false') {
   queueCiMessage();
 }
 else {
-  console.log('This is not a commit to master, not sending message to CI queue');
-}*/
-
-
-queueCiMessage();
+  console.log('This is not a commit to master, not sending message to CI queue.');
+}
 


### PR DESCRIPTION
- Allows publishing to iron queue for repositories that do not use gulp
- Requires a config file .publish_options.js to be defined in the repository that wants to use this. It specifies the options for the [frau-publisher](https://github.com/Brightspace/frau-publisher)
- Also we should probably put all our CI scripts into a repo in the Brightspace organization or Stash

@jmurray87 

Also I realized that when we increment a patch it probably will not be in the master branch. The generate_tag.sh script might have to be updated for this.
