### PR TITLE
print entire git log

### DIFF
--- a/generate_tag.sh
+++ b/generate_tag.sh
@@ -34,7 +34,7 @@ setGitUser() {
 
 if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
   CURRENT_VERSION=$(grep -Po '(?<="version": ")[^"]*' package.json)
-  LAST_MESSAGE=$(git log -1 --oneline)
+  LAST_MESSAGE=$(git log -1 --pretty=full)
   UPDATE_TYPE=minor
   UPDATE_TYPE_OVERRIDE=$(echo $LAST_MESSAGE | grep -oP '(?:(?<=\[).+?(?=\]))')
   echo "Debug - Last message is: $LAST_MESSAGE"


### PR DESCRIPTION
I think git limits the log message to 75 characters unless you specifiy you want the whole thing.

@mtjandra 
@jmurray87 
